### PR TITLE
Fix edge case where period after a link gets escaped

### DIFF
--- a/markdown/main.go
+++ b/markdown/main.go
@@ -346,7 +346,7 @@ func isNumber(data []byte) bool {
 			return false
 		}
 	}
-	return true
+	return len(data) > 0
 }
 
 func needsEscaping(text []byte, lastNormalText string) bool {

--- a/markdown/testdata/url.golden.md
+++ b/markdown/testdata/url.golden.md
@@ -1,0 +1,3 @@
+Lorem [ipsum](https://www.example.com).
+
+Lorem [ipsum](https://www.example.com).

--- a/markdown/testdata/url.in.md
+++ b/markdown/testdata/url.in.md
@@ -1,0 +1,3 @@
+Lorem [ipsum](https://www.example.com).
+
+Lorem [ipsum](https://www.example.com)\.


### PR DESCRIPTION
Before:

```markdown
Lorem [ipsum](http://example.com)\.
```

After:

```markdown
Lorem [ipsum](http://example.com).
```

This one's been bothering me for ages but I never manged to track it down until today! :smile:

(Thanks for writing such a great tool. :heart:)